### PR TITLE
styling adjustments on landing page

### DIFF
--- a/src/components/KickoffCTA.tsx
+++ b/src/components/KickoffCTA.tsx
@@ -1,0 +1,37 @@
+import { ExternalLinkIcon } from "@chakra-ui/icons";
+import { Box, Button, Heading } from "@chakra-ui/react";
+import { GrowEvent } from "modules/events/types";
+import React from "react";
+
+interface KickoffCTAProps {
+    today: Date;
+    kickoff: GrowEvent;
+}
+
+const KickoffCTA: React.FC<KickoffCTAProps> = ({ today, kickoff }) => {
+    const kickoffDate = kickoff.date;
+    const kickoffHref = kickoff.href;
+    if (!(today < kickoffDate && kickoffHref && kickoffHref.length > 0)) {
+        return null;
+    }
+
+    const handleClick = () => {
+        if (kickoffHref) window.location.href = kickoffHref;
+    };
+
+    return (
+        <Box paddingTop={2} paddingBottom={2}>
+            <Button
+                padding={6}
+                paddingLeft={8}
+                paddingRight={8}
+                leftIcon={<ExternalLinkIcon />}
+                onClick={handleClick}
+            >
+                <Heading size={{ base: "m", md: "l" }}>Sign Up for the Kickoff!</Heading>
+            </Button>
+        </Box>
+    );
+};
+
+export default KickoffCTA;

--- a/src/modules/landing/Footer.tsx
+++ b/src/modules/landing/Footer.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Flex, Icon, Image, Link, Spacer } from '@chakra-ui/react';
+import { Box, Divider, Flex, Icon, Image, Link, Spacer, Text } from '@chakra-ui/react';
 import NextLink from 'next/link';
 import { FaGithub } from 'react-icons/fa';
 
@@ -24,23 +24,66 @@ export default function Footer() {
                         />
                     </Link>
 
+                    <Flex flexDir="column" color="gray.300">
+                        <NextLink href="/#faqs" legacyBehavior>
+                            <Link>FAQ</Link>
+                        </NextLink>
+                        <Link href="mailto:grow@pioniergarage.de">Contact</Link>
+                        <Link href="https://pioniergarage.de/impressum/">
+                            Impressum
+                        </Link>
+                    </Flex>
 
+                </Flex>
 
-                    <Flex
-                        gap={6}
+                <Flex
+                    gap={4}
+                    alignItems="center"
+                    justifyContent="center"
+                    flexDirection='column'
+                    mt={10}
+                >
+                    <Text fontSize="xl">
+                        Follow us!
+                    </Text>
+
+                    <Flex gap={10}
                         alignItems="center"
-                        height="2rem"
                         position="relative"
                         justifyContent="center"
+                        flexDirection='row'
+                        mb='0'
                     >
-                        <h3 style={{ position: "absolute", top: "-1.5rem", width: "100%", textAlign: "center" }}>
-                            Follow us!
-                        </h3>
                         <Link href="https://www.instagram.com/pioniergarage_ev/">
+                            <Box
+                                maxW="container.xl"
+                                top={0}
+                                w="100%"
+                                h="100%"
+                                position="absolute"
+                                zIndex={-10}
+                            >
+                                <Box
+                                    position="absolute"
+                                    width="100%"
+                                    height="100%"
+                                    bgGradient="linear-gradient(128.16deg, #ffffff 8.06% , #5557f777 83.26%)"
+                                    borderRadius="50%"
+                                    filter="blur(35px)"
+                                />
+                            </Box>
                             <Image
                                 height="2rem"
                                 src="/images/icons/instagram.svg"
                                 alt="Pioniergarage Instagram"
+                                objectFit="contain"
+                            />
+                        </Link>
+                        <Link href="https://chat.whatsapp.com/L3wQLnRULEb33YkFGS1pDx">
+                            <Image
+                                height="2rem"
+                                src="/images/icons/whatsapp.svg"
+                                alt="Pioniergarage WhatsApp"
                                 objectFit="contain"
                             />
                         </Link>
@@ -52,32 +95,9 @@ export default function Footer() {
                                 objectFit="contain"
                             />
                         </Link>
-                        <Link href="https://chat.whatsapp.com/GuhNZppcwLz3ngxY79LcWb">
-                            <Image
-                                height="2rem"
-                                src="/images/icons/whatsapp.svg"
-                                alt="Pioniergarage WhatsApp"
-                                objectFit="contain"
-                            />
-                        </Link>
                     </Flex>
-
-
-
-
-                    <Flex flexDir="column" color="gray.300">
-                        <NextLink href="/#faqs" legacyBehavior>
-                            <Link>FAQ</Link>
-                        </NextLink>
-                        <Link href="mailto:grow@pioniergarage.de">Contact</Link>
-                        <Link href="https://pioniergarage.de/impressum/">
-                            Impressum
-                        </Link>
-                    </Flex>
-
-
-
                 </Flex>
+
                 <Flex
                     flexDir="column"
                     mt={10}

--- a/src/modules/landing/MainInfoBlock.tsx
+++ b/src/modules/landing/MainInfoBlock.tsx
@@ -1,13 +1,11 @@
-import { ExternalLinkIcon } from '@chakra-ui/icons';
+import KickoffCTA from '@/components/KickoffCTA';
 import {
     Box,
-    Button,
     Flex,
     Grid,
     GridItem,
     Heading,
     Show,
-    Spacer,
     Text
 } from '@chakra-ui/react';
 import EventTag from 'modules/events/components/EventTag';
@@ -19,6 +17,7 @@ import AnimatedLogo from './AnimatedLogo';
 type InfoBlockProps = {
     kickoff: GrowEvent;
     final: GrowEvent;
+    today: Date;
 };
 
 function Fact({ amount, title, location }: { amount: string; title: string, location: string }) {
@@ -42,9 +41,9 @@ function Fact({ amount, title, location }: { amount: string; title: string, loca
 
 const MainInfoBlock: React.FC<InfoBlockProps> = ({
     kickoff,
-    final
+    final,
+    today
 }) => {
-    const today = new Date();
     return (
         <Grid
             templateColumns={{ base: '1fr', lg: '3fr 2fr' }}
@@ -104,20 +103,14 @@ const MainInfoBlock: React.FC<InfoBlockProps> = ({
                         <Flex flexDir="column"
                             gap={4}
                             align={{ base: 'center', md: 'start' }}
+                            mb={8}
                         >
                             <Fact
                                 title="Start Kick-Off"
                                 amount={growFormattedDate(kickoff.date, today)}
                                 location={kickoff.location}
                             />
-                            {(today < kickoff.date && kickoff.href && kickoff.href.length > 0) &&
-                                <Box paddingTop={2} paddingBottom={2}>
-                                    <Button padding={6} paddingLeft={8} paddingRight={8} leftIcon={<ExternalLinkIcon />} onClick={() => { if (kickoff.href) window.location.href = kickoff.href }}><Heading size={{ base: 'm', md: 'l' }}>
-                                        Sign Up for the Kickoff!
-                                    </Heading></Button>
-                                    <Spacer mb='8' />
-                                </Box>
-                            }
+                            <KickoffCTA today={today} kickoff={kickoff} />
                         </Flex>
                         <Fact
                             title="Finale in Karlsruhe"

--- a/src/modules/landing/WaitingForBlock.tsx
+++ b/src/modules/landing/WaitingForBlock.tsx
@@ -1,22 +1,42 @@
-import { Flex, Heading, Text, VStack } from '@chakra-ui/react';
+import { Box, Flex, Heading, Text, VStack } from '@chakra-ui/react';
 
 export default function WaitingForBlock() {
     return (
-        <VStack mx={8}>
-            <Heading size="lg" textAlign="center">
-                What Are You Waiting For?
-            </Heading>
-            <Flex maxW="xl" gap={6} alignItems="center" flexDirection="column">
-                <Text textAlign="center">
-                    If you are motivated to work with other students on new
-                    ideas and concepts and want to learn all about startups,
-                    then{' '}
-                    <Text as="span" fontWeight="semibold">
-                        GROW
-                    </Text>{' '}
-                    is the place for you!
-                </Text>
-            </Flex>
-        </VStack>
+        <>
+            <Box
+                maxW="container.xl"
+                top={0}
+                w="100%"
+                h="100%"
+                position="absolute"
+                zIndex={-10}
+            >
+                <Box
+                    position="absolute"
+                    width="100%"
+                    height="100%"
+                    bgGradient="linear-gradient(128.16deg, #5557f777 8.06% , #5557f777 83.26%)"
+                    borderRadius="50%"
+                    filter="blur(150px)"
+                />
+            </Box>
+            <VStack mx={8}>
+                <Heading size="lg" textAlign="center">
+                    What Are You Waiting For?
+                </Heading>
+                <Flex maxW="xl" gap={6} alignItems="center" flexDirection="column">
+                    <Text textAlign="center">
+                        If you are motivated to work with other students on new
+                        ideas and concepts and want to learn all about startups,
+                        then{' '}
+                        <Text as="span" fontWeight="semibold">
+                            GROW
+                        </Text>{' '}
+                        is the place for you!
+                    </Text>
+                </Flex>
+            </VStack>
+        </>
+
     );
 }

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,4 +1,5 @@
-import { Box, BoxProps, Divider } from '@chakra-ui/react';
+import KickoffCTA from '@/components/KickoffCTA';
+import { Box, BoxProps, Divider, Flex } from '@chakra-ui/react';
 import { createClient } from '@supabase/supabase-js';
 import fs from "fs";
 import ical, { ICalCalendarMethod } from 'ical-generator';
@@ -80,9 +81,10 @@ const Home: React.FC<HomeProps> = ({
     const kickoff: GrowEvent = events.filter((e) => e.ref == 'kickoff')[0]
     const midterm: GrowEvent = events.filter((e) => e.ref == 'midterm')[0]
     const final: GrowEvent = events.filter((e) => e.ref == 'final')[0]
+    const today = new Date();
     return (
         <>
-            <Section position="relative" minH="80vh">
+            <Section position="relative" minH="75vh">
                 <Box
                     maxW="container.xl"
                     transform="translate(0, -50%)"
@@ -101,7 +103,7 @@ const Home: React.FC<HomeProps> = ({
                         filter={{ base: 'blur(80px)', md: 'blur(150px)' }}
                     />
                 </Box>
-                <MainInfoBlock kickoff={kickoff} final={final} />
+                <MainInfoBlock kickoff={kickoff} final={final} today={today} />
             </Section>
 
             <Divider mb={12} />
@@ -122,7 +124,7 @@ const Home: React.FC<HomeProps> = ({
                 <MotivationBlock />
             </Section>
 
-            <Section id="timeline" mt="4rem" my="12rem">
+            <Section id="timeline" mt="16rem" mb="4rem">
                 {events.length > 3 ?
                     <LongTimeline events={events} kickoffDate={kickoff.date} />
                     :
@@ -130,28 +132,17 @@ const Home: React.FC<HomeProps> = ({
                 }
             </Section>
 
-            <Section position="relative" my={24} px={0}>
-                <Box
-                    maxW="container.xl"
-                    top={0}
-                    w="100%"
-                    h="100%"
-                    position="absolute"
-                    zIndex={-10}
-                >
-                    <Box
-                        position="absolute"
-                        width="100%"
-                        height="100%"
-                        bgGradient="linear-gradient(128.16deg, #5557f777 8.06% , #5557f777 83.26%)"
-                        borderRadius="50%"
-                        filter="blur(150px)"
-                    />
-                </Box>
+            <Section position="relative" px={0}>
                 <WaitingForBlock />
+                <Flex flexDir="column"
+                    align='center'
+                    mt={4}
+                >
+                    <KickoffCTA today={today} kickoff={kickoff} />
+                </Flex>
             </Section>
 
-            <Divider my={24} />
+            <Divider my={16} />
 
             <Section my={24}>
                 <SponsorsAndSupporters sponsors={sponsors} />


### PR DESCRIPTION
adjustet the styling a bit, so the cta is visible right away (on smaller desktop screens, e.g. 13'' MacBook)

<img width="1285" height="795" alt="image" src="https://github.com/user-attachments/assets/2a8a9e53-4064-446e-ad6d-7ff20e03dbad" />
